### PR TITLE
Tooley fixes

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -569,6 +569,9 @@ namespace SparkleXrm.Tasks
                     break;
 
                 case "CreateMultiple":
+                    image.MessagePropertyName = "Ids";
+                    break;
+                    
                 case "UpdateMultiple":
                     image.MessagePropertyName = "Targets";
                     break;

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -568,6 +568,11 @@ namespace SparkleXrm.Tasks
                     image.MessagePropertyName = "EmailId";
                     break;
 
+                case "CreateMultiple":
+                case "UpdateMultiple":
+                    image.MessagePropertyName = "Targets";
+                    break;
+                    
                 default:
                     image.MessagePropertyName = "Target";
                     break;


### PR DESCRIPTION
Corrected CreateMultiple image message property name
CreateMultiple requires message property name to be set to Ids rather than Targets.

Added image support for bulk message steps
Supports images on CreateMultiple & UpdateMultiple messages
